### PR TITLE
Save correct checkbox values

### DIFF
--- a/includes/admin/class-noptin-vue.php
+++ b/includes/admin/class-noptin-vue.php
@@ -536,7 +536,7 @@ class Noptin_Vue {
 
 		// Checkbox.
 		if ( 'checkbox' === $field['type']['type'] ) {
-			$value = __( 'No', 'newsletter-optin-box' );
+			$value = __( 'Yes', 'newsletter-optin-box' );
 			echo "<label><input name='$name' type='checkbox' value='$value' class='noptin-checkbox-form-field' $required/><span>$label</span></label>";
 		}
 

--- a/templates/admin-single-subscriber/checkbox.php
+++ b/templates/admin-single-subscriber/checkbox.php
@@ -11,8 +11,8 @@
                     class="regular-checkbox"
                     name="noptin_custom_field[<?php echo $name; ?>]"
                     id="custom_field_<?php echo $id; ?>"
-                    value="1"
-                    <?php checked( ! empty( $value ) ); ?>
+                    value="<?php __( 'Yes', 'newsletter-optin-box' ); ?>"
+                    <?php checked( ! empty( $value ) && ( $value == 1 || strtolower( $value ) == 'yes') ); ?>
                 >
                 <span><?php echo $label; ?></span>
             </label>


### PR DESCRIPTION
## Description
- Fixed a bug in the checkbox values that were always saved as 'no'.
- Fixed a bug showing checkboxes selected in the admin interface, even if value was 'no'.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested manually in local environment (latest WordPress + Noptin master).

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fixes

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
