### PR TITLE
Use static value for checkbox to prevent problems with translated values

### DIFF
--- a/includes/admin/class-noptin-vue.php
+++ b/includes/admin/class-noptin-vue.php
@@ -643,7 +643,7 @@ class Noptin_Vue {
 
 		// Checkbox.
 		if ( 'checkbox' === $field['type']['type'] ) {
-			$value = esc_attr__( 'Yes', 'newsletter-optin-box' );
+			$value = '1'; // Use static value to prevent problems with translated values being saved into the database
 			echo "<label><input name='$name' type='checkbox' value='$value' class='noptin-checkbox-form-field' $required/><span>$label</span></label>";
 		}
 

--- a/templates/admin-single-subscriber/checkbox.php
+++ b/templates/admin-single-subscriber/checkbox.php
@@ -11,7 +11,7 @@
                     class="regular-checkbox"
                     name="noptin_custom_field[<?php echo $name; ?>]"
                     id="custom_field_<?php echo $id; ?>"
-                    value="<?php esc_attr__( 'Yes', 'newsletter-optin-box' ); ?>"
+                    value="1"
                     <?php checked( ! empty( $value ) && ( $value == 1 || strtolower( $value ) == strtolower( esc_attr__( 'Yes', 'newsletter-optin-box' ) ) ) ); ?>
                 >
                 <span><?php echo $label; ?></span>


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Use static values for form checkboxes. When several languages are being used on the site, 'yes' might have different value based on the user language settings. UI will not render correctly because values in the database might be different to the expected string. 

For example: user language is Finnish (yes -> "kyllä") and administrator is using website in English (yes -> "yes"). Value comparison will not work correctly.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested manually.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
