### PR TITLE
chore: migrate Renovate preset to recommended

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
   "extends": [
-    "config:base"
+    "config:recommended"
   ]
 }


### PR DESCRIPTION
Renovate's Dependency Dashboard currently reports **Config Migration Needed** in #342.

This keeps the existing single preset and updates it from the deprecated `config:base` preset to `config:recommended`, which is Renovate's current recommended default.

Validation run locally:
- `python3 -m json.tool renovate.json`
- `git diff --check`

No dependency versions or application code changed.