### PR TITLE
feat(WPForms): prevent duplicate submissions and introduce customization filters

### DIFF
--- a/src/Integrations/WPForms/Main.php
+++ b/src/Integrations/WPForms/Main.php
@@ -50,6 +50,7 @@ class Main extends \Hizzle\Noptin\Integrations\Form_Integration {
 		if ( function_exists( 'add_noptin_subscriber' ) ) {
 			add_filter( 'wpforms_builder_settings_sections', array( $this, 'settings_section' ) );
 			add_action( 'wpforms_form_settings_panel_content', array( $this, 'settings_section_content' ), 20 );
+			add_action( 'wpforms_process_validate_email', array( $this, 'validate_email' ), 10, 3 );
 		}
 	}
 
@@ -369,5 +370,46 @@ class Main extends \Hizzle\Noptin\Integrations\Form_Integration {
 
 		// Add subscriber.
 		add_noptin_subscriber( $prepared );
+	}
+
+	/**
+	 * Validate email address submitted via WPForms.
+	 *
+	 * @param int   $field_id     Field ID.
+	 * @param mixed $field_submit Field submit value.
+	 * @param array $form_data    Form data and settings.
+	 */
+	public function validate_email( $field_id, $field_submit, $form_data ) {
+		// Check that the form was configured for email subscriptions.
+		if ( ! function_exists( 'noptin_get_subscriber' ) || empty( $form_data['settings']['enable_noptin'] ) || '1' !== $form_data['settings']['enable_noptin'] ) {
+			return;
+		}
+
+		// Check if this is the mapped email field.
+		$mapped_email_field_id = isset( $form_data['settings']['noptin_field_email'] ) ? $form_data['settings']['noptin_field_email'] : '';
+		if ( '' === $mapped_email_field_id || (int) $field_id !== (int) $mapped_email_field_id ) {
+			return;
+		}
+
+		// Retrieve the email address.
+		$email = is_array( $field_submit ) ? ( isset( $field_submit['value'] ) ? $field_submit['value'] : '' ) : $field_submit;
+		$email = sanitize_email( $email );
+
+		if ( empty( $email ) || ! is_email( $email ) ) {
+			return;
+		}
+
+		// Check if duplicate submission prevention is enabled.
+		$prevent_duplicate = apply_filters( 'noptin_prevent_duplicate_submission', true, $email, $form_data, $field_id );
+		if ( ! $prevent_duplicate ) {
+			return;
+		}
+
+		// Check if the user is already subscribed.
+		$subscriber = noptin_get_subscriber( $email );
+		if ( $subscriber->is_active() ) {
+			$error_message = apply_filters( 'noptin_wpforms_duplicate_email_error_message', __( 'This email address is already subscribed.', 'newsletter-optin-box' ), $email, $form_data );
+			wpforms()->process->errors[ $form_data['id'] ][ $field_id ] = $error_message;
+		}
 	}
 }

--- a/src/Integrations/WPForms/Main.php
+++ b/src/Integrations/WPForms/Main.php
@@ -110,10 +110,16 @@ class Main extends \Hizzle\Noptin\Integrations\Form_Integration {
 				continue;
 			}
 
-			$key = sanitize_title( $wpforms_field['label'] );
+			$label = ! empty( $wpforms_field['label'] ) ? $wpforms_field['label'] : '';
+
+			if ( '' === $label && isset( $wpforms_field['id'] ) ) {
+				$label = sprintf( __( 'Field #%d', 'newsletter-optin-box' ), $wpforms_field['id'] );
+			}
+
+			$key = sanitize_title( $label );
 
 			$prepared_fields[ $key ] = array(
-				'description'       => $wpforms_field['label'],
+				'description'       => $label,
 				'conditional_logic' => 'number' === $wpforms_field['type'] ? 'number' : 'string',
 			);
 


### PR DESCRIPTION
## Description
This PR addresses the feature request for preventing duplicate submissions when integrating Noptin with WPForms (closes https://github.com/hizzle-co/noptin/issues/1041).

### Added:
1. **Duplicate Submission Validation Check**: Hooked into WPForms validation (`wpforms_process_validate_email`) to verify if the submitting user's email address is already active as a subscriber in Noptin. If they are, it blocks the form submission and displays a validation error.
2. **Introduced 2 Customization Filters**:
   * `noptin_prevent_duplicate_submission` (default `true`): Named generically so Noptin can reuse it in the future across other form integrations to enable/disable duplicate checks.
   * `noptin_wpforms_duplicate_email_error_message`: Used specifically to customize or translate the validation error message.

### Fixed:
* **PHP Warnings and Deprecations in WPForms integration**: Fixed `PHP Warning: Undefined array key "label"` and PHP Deprecation notices in `preg_match`/`strip_tags` (occurring on PHP 8.1+ when passing `null` to sanitizers) during WPForms field mapping. This happens if a mapped field does not have a label key configured. It now gracefully defaults to a localized `"Field #{ID}"` fallback.

## How has this been tested?
* Tested locally on a WordPress environment with **WPForms** and **Noptin** active.
* Configured a WPForms form to enable Noptin subscriptions.
* Submitted the form with an email that is already registered as an active subscriber in Noptin.
* Verified that the form validation halts the submission and returns the expected message: *"This email address is already subscribed."*
* Verified code standards manually against Noptin's `phpcs.xml.dist` ruleset (tab indentation, operator spacing, bracket rules, i18n text domain checking).

## Screenshots
<img width="1558" height="360" alt="image" src="https://github.com/user-attachments/assets/00ed6052-fdd4-456f-9684-10c47b363bbb" />

<img width="928" height="625" alt="image" src="https://github.com/user-attachments/assets/ecf22996-85cf-4aab-91c5-1745d29263ce" />

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.
- [x] I've included developer documentation if appropriate.
